### PR TITLE
Provide a way to retrieve the host of the started minio container

### DIFF
--- a/__tests__/minio/minio-extension.t.ts
+++ b/__tests__/minio/minio-extension.t.ts
@@ -9,6 +9,7 @@ describe("MinioExtension", () => {
     }
 
     delete process.env.MINIO_EXTENSION_PORT;
+    delete process.env.MINIO_EXTENSION_HOST;
   });
 
   describe("startMinioContainer", () => {
@@ -17,6 +18,7 @@ describe("MinioExtension", () => {
 
       expect(global.MINIO_CONTAINER).toBeDefined();
       expect(process.env.MINIO_EXTENSION_PORT).toBeDefined();
+      expect(process.env.MINIO_EXTENSION_HOST).toBeDefined();
     }, 60_000);
   });
 
@@ -27,6 +29,7 @@ describe("MinioExtension", () => {
 
       expect(global.MINIO_CONTAINER).toBeUndefined();
       expect(process.env.MINIO_EXTENSION_PORT).toBeUndefined();
+      expect(process.env.MINIO_EXTENSION_HOST).toBeUndefined();
     }, 60_000);
 
     it("should throw error when container is not previously started", () => {
@@ -41,7 +44,7 @@ describe("MinioExtension", () => {
   });
 
   describe("setMinioPort", () => {
-    it("should set the uri env variable for the minio port", () => {
+    it("should set the port env variable for the minio port", () => {
       MinioExtension.setMinioPort(12345);
 
       expect(process.env.MINIO_EXTENSION_PORT).toEqual("12345");
@@ -58,6 +61,29 @@ describe("MinioExtension", () => {
 
     it("should throw error when container is not previously started", () => {
       expect(() => MinioExtension.getMinioPort()).toThrow(
+        "IllegalStateException: Minio container has not been previously started",
+      );
+    });
+  });
+
+  describe("setMinioHost", () => {
+    it("should set the host env variable for the minio host", () => {
+      MinioExtension.setMinioHost("min.io");
+
+      expect(process.env.MINIO_EXTENSION_HOST).toEqual("min.io");
+    });
+  });
+
+  describe("getMinioHost", () => {
+    it("should return the host for the started container", async () => {
+      await MinioExtension.startMinioContainer();
+
+      const host = MinioExtension.getMinioHost();
+      expect(host).toEqual("localhost");
+    }, 60_000);
+
+    it("should throw error when container is not previously started", () => {
+      expect(() => MinioExtension.getMinioHost()).toThrow(
         "IllegalStateException: Minio container has not been previously started",
       );
     });

--- a/src/minio/minio-extension.ts
+++ b/src/minio/minio-extension.ts
@@ -28,6 +28,7 @@ async function startMinioContainer(
     .start();
 
   setMinioPort(container.getMappedPort(9000));
+  setMinioHost(container.getHost());
 
   // NOTE: This will only work if tests are runInBand (i.e. not in parallel)
   global.MINIO_CONTAINER = container;
@@ -45,10 +46,15 @@ async function stopMinioContainer() {
   await global.MINIO_CONTAINER.stop();
   global.MINIO_CONTAINER = undefined;
   delete process.env.MINIO_EXTENSION_PORT;
+  delete process.env.MINIO_EXTENSION_HOST;
 }
 
 function setMinioPort(port: number) {
   process.env.MINIO_EXTENSION_PORT = String(port);
+}
+
+function setMinioHost(host: string) {
+  process.env.MINIO_EXTENSION_HOST = host;
 }
 
 /**
@@ -64,9 +70,26 @@ function getMinioPort(): number {
   return parseInt(process.env.MINIO_EXTENSION_PORT, 10);
 }
 
+/**
+ * Retrieves the host of the started Minio container. Error will be thrown if startMinioContainer was
+ * not previously called.
+ *
+ * Note: In most cases this should return localhost.
+ */
+function getMinioHost(): string {
+  KiwiPreconditions.checkState(
+    process.env.MINIO_EXTENSION_HOST !== undefined,
+    "Minio container has not been previously started",
+  );
+
+  return process.env.MINIO_EXTENSION_HOST;
+}
+
 export const MinioExtension = {
   startMinioContainer,
   stopMinioContainer,
   setMinioPort,
   getMinioPort,
+  getMinioHost,
+  setMinioHost,
 };


### PR DESCRIPTION
While in almost all cases this will return `localhost` due to the fact that the containers are started locally, adding this getter allows for consistency across extensions. Also, if the option to bind the minio container to another address is introduced, then the getter will be crucial.

* Add tests

Closes #59 