### PR TITLE
Add enhancements for waitForIt

### DIFF
--- a/__tests__/waitForIt/waitForIt.t.ts
+++ b/__tests__/waitForIt/waitForIt.t.ts
@@ -1,16 +1,20 @@
-import { describe, expect, it } from "@jest/globals";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
 import { wait } from "../../src";
 
-describe("Awaitility", () => {
+describe("WaitForIt", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("should resolve when condition passes", () => {
     wait().until(() => true);
   });
 
   it("should reject when condition runs out of tries", async () => {
     await expect(wait().until(() => false)).rejects.toEqual(
-      new Error("Condition was not met after 5 tries"),
+      new Error("Condition was not met after 40 tries"),
     );
-  });
+  }, 6_000);
 
   it("should allow for setting the wait time", async () => {
     await expect(
@@ -20,12 +24,107 @@ describe("Awaitility", () => {
     ).rejects.toEqual(new Error("Condition was not met after 2 tries"));
   });
 
+  it("should allow for setting the wait time defaulting units to ms", async () => {
+    await expect(
+      wait()
+        .atMost(200)
+        .until(() => false),
+    ).rejects.toEqual(new Error("Condition was not met after 2 tries"));
+  });
+
   it("should allow for setting the interval check time", async () => {
     await expect(
       wait()
         .atMost(200, "ms")
-        .checkEvery(10, "ms")
+        .withPollInterval(10, "ms")
         .until(() => false),
     ).rejects.toEqual(new Error("Condition was not met after 20 tries"));
+  });
+
+  it("should allow for setting the interval check time defaulting to ms units", async () => {
+    await expect(
+      wait()
+        .atMost(200, "ms")
+        .withPollInterval(10)
+        .until(() => false),
+    ).rejects.toEqual(new Error("Condition was not met after 20 tries"));
+  });
+
+  it("should allow for setting the poll delay time", async () => {
+    await expect(
+      wait()
+        .atMost(200, "ms")
+        .withPollInterval(10, "ms")
+        .withPollDelay(20, "ms")
+        .until(() => false),
+    ).rejects.toEqual(new Error("Condition was not met after 20 tries"));
+  });
+
+  it("should allow for setting the poll delay time defaulting the units to ms", async () => {
+    await expect(
+      wait()
+        .atMost(200, "ms")
+        .withPollInterval(10, "ms")
+        .withPollDelay(20)
+        .until(() => false),
+    ).rejects.toEqual(new Error("Condition was not met after 20 tries"));
+  });
+
+  it("should allow for enabling verbose mode with success messages", async () => {
+    const consoleSpy = jest.spyOn(global.console, "log");
+
+    await expect(
+      wait()
+        .atMost(200, "ms")
+        .withPollInterval(10, "ms")
+        .withVerbose()
+        .until(() => true),
+    ).resolves.toEqual("Condition met after 1 of 20 tries");
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Waiting for condition for up to 20 attempts checking every 10 ms",
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Condition met after 1 of 20 tries",
+    );
+  });
+
+  it("should allow for enabling verbose mode with failed messages", async () => {
+    const consoleSpy = jest.spyOn(global.console, "log");
+
+    await expect(
+      wait()
+        .atMost(200, "ms")
+        .withPollInterval(10, "ms")
+        .withVerbose()
+        .until(() => false),
+    ).rejects.toEqual(new Error("Condition was not met after 20 tries"));
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Waiting for condition for up to 20 attempts checking every 10 ms",
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Condition was not met after 20 tries",
+    );
+  });
+
+  it("should allow for adding an alias ", async () => {
+    const consoleSpy = jest.spyOn(global.console, "log");
+
+    await expect(
+      wait()
+        .atMost(200, "ms")
+        .withPollInterval(10, "ms")
+        .withVerbose()
+        .withAlias("KIWI")
+        .until(() => true),
+    ).resolves.toEqual("Condition with alias KIWI met after 1 of 20 tries");
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Waiting for condition with alias KIWI for up to 20 attempts checking every 10 ms",
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Condition with alias KIWI met after 1 of 20 tries",
+    );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kiwiproject/kiwi-test-js",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kiwiproject/kiwi-test-js",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@elastic/elasticsearch": "8.12.2",
         "@jest/globals": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiwiproject/kiwi-test-js",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "kiwi-test-js is a test utility library. Most of these utilities are ports from the Java Kiwi-test library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/waitForIt/waitForIt.ts
+++ b/src/waitForIt/waitForIt.ts
@@ -1,46 +1,128 @@
 import convert, { Time } from "convert";
 
+/**
+ * Creates a new wait condition with defaults.
+ *
+ * Impl Note: This will NOT do anything unless `.until()` is called.
+ */
 export function wait(): WaitFor {
   return new WaitFor();
 }
 
 class WaitFor {
   private timeoutMs: number;
-  private checkIntervalMs: number;
+  private pollIntervalMs: number;
+  private pollDelayMs: number;
+  private alias: string;
+  private verbose: boolean;
 
   constructor() {
-    this.timeoutMs = 500;
-    this.checkIntervalMs = 100;
+    this.timeoutMs = 4_000;
+    this.pollIntervalMs = 100;
+    this.pollDelayMs = 0;
+    this.verbose = false;
   }
 
-  atMost(time: number, units: Time): this {
+  /**
+   * Sets the amount of time between condition checks to wait.
+   * @param time The amount of time till the next poll
+   * @param units The units that correspond to the time. Default is ms.
+   */
+  withPollInterval(time: number, units: Time = "ms"): this {
+    this.pollIntervalMs = convert(time, units).to("ms");
+    return this;
+  }
+
+  /**
+   * Sets the amount of time to wait until the condition is first checked.
+   * @param time The amount of time to wait
+   * @param units The units corresponding to the time. Default is ms.
+   */
+  withPollDelay(time: number, units: Time = "ms"): this {
+    this.pollDelayMs = convert(time, units).to("ms");
+    return this;
+  }
+
+  /**
+   * A unique name to give this wait check. Useful if more than one wait condition is used.
+   *
+   * @param alias The name to give this wait check.
+   */
+  withAlias(alias: string): this {
+    this.alias = alias;
+    return this;
+  }
+
+  /**
+   * Enables debug logging during the wait check.
+   */
+  withVerbose(): this {
+    this.verbose = true;
+    return this;
+  }
+
+  /**
+   * Sets the max time to wait for the condition to return true.
+   * @param time The amount of total time to wait for the condition to return true.
+   * @param units The units that correspond to the time. Default is ms.
+   */
+  atMost(time: number, units: Time = "ms"): this {
     this.timeoutMs = convert(time, units).to("ms");
     return this;
   }
 
-  checkEvery(time: number, units: Time): this {
-    this.checkIntervalMs = convert(time, units).to("ms");
-    return this;
-  }
-
+  /**
+   * Kicks off the wait check. The condition will be checked every pollInterval for a truthy response. If the max time
+   * to wait is reached, then a rejected Promise will be returned. If the condition becomes true, then a resolved Promise
+   * will be returned.
+   * @param cb The function to check if the condition is true or false.
+   */
   until(cb: () => boolean): Promise<string> {
-    const totalTries = this.timeoutMs / this.checkIntervalMs;
+    const totalTries = this.timeoutMs / this.pollIntervalMs;
+
+    const aliasText = this.alias ? `with alias ${this.alias} ` : "";
+
+    if (this.verbose) {
+      console.log(
+        `Waiting for condition ${aliasText}for up to ${totalTries} attempts checking every ${this.pollIntervalMs} ms`,
+      );
+    }
 
     return new Promise((resolve, reject) => {
       let tries = 1;
 
       const loop = () => {
         if (cb.apply(this)) {
-          resolve(`Condition met after ${tries} of ${totalTries} tries`);
+          if (this.verbose) {
+            console.log(
+              `Condition ${aliasText}met after ${tries} of ${totalTries} tries`,
+            );
+          }
+          resolve(
+            `Condition ${aliasText}met after ${tries} of ${totalTries} tries`,
+          );
         } else if (tries > totalTries) {
-          reject(new Error(`Condition was not met after ${totalTries} tries`));
+          if (this.verbose) {
+            console.log(
+              `Condition ${aliasText}was not met after ${totalTries} tries`,
+            );
+          }
+          reject(
+            new Error(
+              `Condition ${aliasText}was not met after ${totalTries} tries`,
+            ),
+          );
         } else {
           tries += 1;
-          setTimeout(loop, this.checkIntervalMs);
+          setTimeout(loop, this.pollIntervalMs);
         }
       };
 
-      loop();
+      if (this.pollDelayMs > 0) {
+        setTimeout(loop, this.pollDelayMs);
+      } else {
+        loop();
+      }
     });
   }
 }


### PR DESCRIPTION
* Add poll delay to delay the start of the check defaulting to no delay
* Add an optional alias to be used when verbose logging is enabled
* Add an option to enable verbose logging *Default units on all chain methods to milliseconds
* Add js docs
* Update tests
* Bump to version 0.5.0

Closes #244