### PR TITLE
feat(postgres): allow tuning the Postgres container for speed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { MongoExtension } from "./mongo/mongo-extension";
 export { PostgresExtension } from "./postgres/postgres-extension";
+export type { StartPostgresContainerOptions } from "./postgres/postgres-extension";
 export { ElasticSearchExtension } from "./elasticsearch/elastic-search-extension";
 export { MinioExtension } from "./minio/minio-extension";
 export { RedisExtension } from "./redis/redis-extension";

--- a/src/postgres/postgres-extension.ts
+++ b/src/postgres/postgres-extension.ts
@@ -142,13 +142,25 @@ function getPostgresUriWithDb(dbName: string): string {
  * startPostgresContainer is not previously called.
  *
  * @param dbName The name of the database to create.
+ * @param template Optional database to copy, via CREATE DATABASE ... TEMPLATE.
+ *
+ * Suites that build their schema once per test file can instead build it once into a template
+ * database and copy that here. Postgres copies the template at the file level, which is
+ * cheaper than replaying the DDL, and the saving grows with the number of test files.
+ *
+ * Postgres refuses to copy a template that has open connections, so close any connection used
+ * to build it before creating databases from it.
  */
-async function setupNewDatabase(dbName: string) {
+async function setupNewDatabase(dbName: string, template?: string) {
   const dbClient = new Client({
     connectionString: getPostgresBaseUrl(),
   });
   await dbClient.connect();
-  await dbClient.query(`create database ${dbName}`);
+  await dbClient.query(
+    template
+      ? `create database ${dbName} template ${template}`
+      : `create database ${dbName}`,
+  );
   await dbClient.end();
 }
 

--- a/src/postgres/postgres-extension.ts
+++ b/src/postgres/postgres-extension.ts
@@ -3,12 +3,87 @@ import { PostgreSqlContainer } from "@testcontainers/postgresql";
 import { Client } from "pg";
 
 /**
+ * Options for tuning the Postgres container started by {@link startPostgresContainer}.
+ *
+ * Both options trade durability for speed. That is safe here because a test container's
+ * data does not outlive the test run, but it means neither should be used against a
+ * container whose contents you expect to survive a crash.
+ */
+export interface StartPostgresContainerOptions {
+  /**
+   * Starts Postgres with fsync, synchronous_commit and full_page_writes turned off.
+   *
+   * Test suites that reset state between tests spend most of their database time in
+   * commit and DDL fsyncs rather than in the queries themselves. Turning durability off
+   * removes those flushes. The gain is largest on slow or IOPS-limited disks, which is
+   * typically CI.
+   *
+   * Defaults to false.
+   */
+  disableDurability?: boolean;
+
+  /**
+   * Places the Postgres data directory on a tmpfs mount so writes never reach the host disk.
+   *
+   * Size the mount for the whole run, not for one database. A suite that creates a database
+   * per test file pays roughly 8 MB per database before any of its own data, so a few hundred
+   * files will exhaust the default. Postgres reports the overflow as
+   * `No space left on device`, which surfaces as widespread and confusing query failures.
+   *
+   * Defaults to false.
+   */
+  tmpfsDataDir?: boolean;
+
+  /**
+   * Size of the tmpfs mount, as a mount(8) size value. Ignored unless tmpfsDataDir is true.
+   *
+   * This is host memory, so it competes with everything else on the machine. Raising it on a
+   * CI runner that executes several jobs concurrently can push the box into swap.
+   *
+   * Defaults to "1g".
+   */
+  tmpfsSize?: string;
+}
+
+// The official postgres image defaults PGDATA to /var/lib/postgresql/data. initdb refuses to
+// run in a directory with group or world access, and a tmpfs mount is created world-writable,
+// so PGDATA is pointed at a subdirectory instead. The entrypoint creates that subdirectory
+// with the permissions and ownership initdb wants.
+const TMPFS_MOUNT_PATH = "/var/lib/postgresql/data";
+const TMPFS_PGDATA_PATH = `${TMPFS_MOUNT_PATH}/pgdata`;
+
+/**
  * Starts a Postgres container and stores the container information in global.POSTGRES_CONTAINER.
  *
  * @param image The image name/version to use for postgres. Defaults to postgres:15.
+ * @param options Optional performance tuning. See {@link StartPostgresContainerOptions}.
  */
-async function startPostgresContainer(image: string = "postgres:15") {
-  const container = await new PostgreSqlContainer(image).start();
+async function startPostgresContainer(
+  image: string = "postgres:15",
+  options: StartPostgresContainerOptions = {},
+) {
+  let containerDef = new PostgreSqlContainer(image);
+
+  if (options.tmpfsDataDir) {
+    const size = options.tmpfsSize ?? "1g";
+    containerDef = containerDef
+      .withTmpFs({ [TMPFS_MOUNT_PATH]: `rw,noexec,nosuid,size=${size}` })
+      .withEnvironment({ PGDATA: TMPFS_PGDATA_PATH });
+  }
+
+  if (options.disableDurability) {
+    containerDef = containerDef.withCommand([
+      "postgres",
+      "-c",
+      "fsync=off",
+      "-c",
+      "synchronous_commit=off",
+      "-c",
+      "full_page_writes=off",
+    ]);
+  }
+
+  const container = await containerDef.start();
   process.env.POSTGRES_EXTENSION_BASE_URI = container.getConnectionUri();
 
   // NOTE: This will only work if tests are runInBand (i.e. not in parallel)


### PR DESCRIPTION
## Why

Test suites that reset database state between tests spend most of their database time in commit and DDL fsyncs rather than in the queries themselves. A test container's data never needs to survive the run, so that durability is pure cost.

This came out of profiling a downstream suite (125 files / 1279 tests) where CI took 598s against 84s on a laptop. The suite turned out to be fsync-bound on the shared Postgres container rather than CPU-bound — worker count barely moved the number, and a file that ran in 5s alone reported 82s inside the full run.

## What

`startPostgresContainer` takes an optional second argument:

- **`disableDurability`** — starts Postgres with `fsync`, `synchronous_commit` and `full_page_writes` off.
- **`tmpfsDataDir`** / **`tmpfsSize`** — puts `PGDATA` on a tmpfs mount.

`setupNewDatabase` takes an optional `template`, so a suite that builds its schema per test file can build it once and copy it via `CREATE DATABASE ... TEMPLATE`.

All options default to off, so existing callers are unaffected.

## Measurements

Against that downstream suite, on local NVMe:

| | Time |
|---|---|
| Baseline | 39.9s |
| `disableDurability: true` | **28.1s** |

The gain should be larger on IOPS-limited CI disks, where an fsync costs far more than it does locally.

## Things worth knowing (documented in the JSDoc)

- **`tmpfsDataDir` needs sizing for the whole run, not one database.** A suite creating a database per test file pays roughly 8 MB each before its own data. At the 1g default, 125 databases exhausted the mount and Postgres reported it as `No space left on device` — surfacing as ~200 unrelated-looking query failures. Sizing it is the fix, but the failure mode is confusing enough to call out.
- **`PGDATA` is pointed at a subdirectory of the tmpfs mount**, because `initdb` refuses to run in a directory with group or world access and tmpfs mounts are created world-writable.
- **A populated template changes bootstrap behaviour.** Every new database already has the schema, so code that keys off whether tables exist yet will take a different path. This bit me downstream: it caused schema-bootstrap logic to stop short-circuiting.

## Testing

Verified by building locally and running it against the real downstream suite (1279 tests) in each configuration — including the tmpfs failure above, which is how the sizing caveat was found.

I did not add unit tests: the repo has a `test` script but no test files or harness for the extensions, and standing that up felt out of scope for this change. Happy to add coverage if you'd like it as part of this PR.