### PR TITLE
ci: drop Node 20 from build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ['20', '22', '24']
+        node_version: ['22', '24']
     steps:
       # Check out the project
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0


### PR DESCRIPTION
## Summary
- Removes Node 20 from the CI build matrix, leaving `['22', '24']`.

Node 20 reached end-of-life on 2026-04-30 and no longer receives security patches.