### PR TITLE
chore: force @actions/http-client's undici to a patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,16 +83,6 @@
         "undici": "^6.23.0"
       }
     },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/@actions/io": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
     "redis": "6.1.0",
     "testcontainers": "12.0.4"
   },
+  "overrides": {
+    "@actions/http-client": {
+      "undici": "^7.29.0"
+    }
+  },
   "devDependencies": {
     "@babel/core": "7.29.7",
     "semantic-release": "25.0.8",


### PR DESCRIPTION
## Summary
- Adds a scoped override in `package.json` forcing `@actions/http-client`'s `undici` dependency to `^7.29.0`.

`@actions/http-client` (pulled in transitively via `@semantic-release/npm`, used only for OIDC/provenance publishing in the release workflow) pins `undici@^6.23.0`, which resolves to a vulnerable `6.28.0` copy. Dependabot's security-update job can't reach that nested copy with a plain `npm update` and fails every run with `Dependabot::NpmAndYarn::FileUpdater::NoChangeError`.

The override is scoped to `@actions/http-client` specifically (not a blanket `undici` override) so `testcontainers`' own `undici@^8.5.0` requirement is untouched — confirmed `testcontainers` still resolves and loads its `8.10.0` copy unaffected.

Verified `@actions/http-client`'s GET/HEAD against a real endpoint still work correctly on the overridden `undici@7.29.0` via a local smoke test before opening this PR (this dependency chain only runs during the manual `workflow_dispatch` release job, so there's no way to exercise it through normal CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbJeyq8eRWr2G7eBta5DPm)_