### PR TITLE
ci: add Node 26 to build and release matrices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ['22', '24']
+        node_version: ['22', '24', '26']
     steps:
       # Check out the project
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ['20', '22', '24']
+        node_version: ['20', '22', '24', '26']
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Adds Node 26 to the CI build matrix and the release workflow's test matrix, alongside the existing versions. Node 26 becomes LTS in October 2026, and this gets ahead of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgmK6SqXwnQozs7SWxY5fg)_